### PR TITLE
Fluent cannot accept null in constructor

### DIFF
--- a/src/Traits/MetableTrait.php
+++ b/src/Traits/MetableTrait.php
@@ -12,7 +12,7 @@ trait MetableTrait
      */
     public function getMetaAttribute($value)
     {
-        $meta = null;
+        $meta = [];
 
         if (! is_null($value)) {
             $meta = json_decode($value, true);


### PR DESCRIPTION
When ```meta``` column empty it will pass ```null``` to the fluent constructor and this will throw an exception. Changing default value for ```$meta``` to and empty array will solve this issue.